### PR TITLE
Catch "Return" key event

### DIFF
--- a/ImGuiRenderer.cpp
+++ b/ImGuiRenderer.cpp
@@ -319,9 +319,24 @@ void ImGuiRenderer::onMousePressedChange(QMouseEvent *event)
 
 void ImGuiRenderer::onWheel(QWheelEvent *event)
 {
-    // 5 lines per unit
-    g_MouseWheelH += event->pixelDelta().x() / (ImGui::GetTextLineHeight());
-    g_MouseWheel += event->pixelDelta().y() / (5.0 * ImGui::GetTextLineHeight());
+    // Handle horizontal component
+    if(event->angleDelta().x() == 0.0)
+    {
+        g_MouseWheelH += event->pixelDelta().x() / (ImGui::GetTextLineHeight());
+    } else {
+        // Magic number of 120 comes from Qt doc on QWheelEvent::pixelDelta()
+        g_MouseWheelH += event->angleDelta().x() / 120;
+    }
+
+    // Handle vertical component
+     if(event->angleDelta().y() == 0.0)
+     {
+         // 5 lines per unit
+         g_MouseWheel += event->pixelDelta().y() / (5.0 * ImGui::GetTextLineHeight());
+     } else {
+         // Magic number of 120 comes from Qt doc on QWheelEvent::pixelDelta()
+         g_MouseWheel += event->angleDelta().y() / 120;
+    }
 }
 
 void ImGuiRenderer::onKeyPressRelease(QKeyEvent *event)

--- a/ImGuiRenderer.cpp
+++ b/ImGuiRenderer.cpp
@@ -23,6 +23,7 @@ QHash<int, ImGuiKey> keyMap = {
     { Qt::Key_Delete, ImGuiKey_Delete },
     { Qt::Key_Backspace, ImGuiKey_Backspace },
     { Qt::Key_Enter, ImGuiKey_Enter },
+    { Qt::Key_Return, ImGuiKey_Enter },
     { Qt::Key_Escape, ImGuiKey_Escape },
     { Qt::Key_A, ImGuiKey_A },
     { Qt::Key_C, ImGuiKey_C },

--- a/demo-widget/demo-widget.cpp
+++ b/demo-widget/demo-widget.cpp
@@ -33,7 +33,7 @@ protected:
         // 2. Show another simple window, this time using an explicit Begin/End pair
         if (show_another_window)
         {
-            ImGui::SetNextWindowSize(ImVec2(200,100), ImGuiSetCond_FirstUseEver);
+            ImGui::SetNextWindowSize(ImVec2(200,100), ImGuiCond_FirstUseEver);
             ImGui::Begin("Another Window", &show_another_window);
             ImGui::Text("Hello");
             ImGui::End();
@@ -42,7 +42,7 @@ protected:
         // 3. Show the ImGui test window. Most of the sample code is in ImGui::ShowTestWindow()
         if (show_test_window)
         {
-            ImGui::SetNextWindowPos(ImVec2(650, 20), ImGuiSetCond_FirstUseEver);
+            ImGui::SetNextWindowPos(ImVec2(650, 20), ImGuiCond_FirstUseEver);
             ImGui::ShowTestWindow();
         }
 

--- a/demo-window/demo-window.cpp
+++ b/demo-window/demo-window.cpp
@@ -33,7 +33,7 @@ protected:
         // 2. Show another simple window, this time using an explicit Begin/End pair
         if (show_another_window)
         {
-            ImGui::SetNextWindowSize(ImVec2(200,100), ImGuiSetCond_FirstUseEver);
+            ImGui::SetNextWindowSize(ImVec2(200,100), ImGuiCond_FirstUseEver);
             ImGui::Begin("Another Window", &show_another_window);
             ImGui::Text("Hello");
             ImGui::End();
@@ -42,7 +42,7 @@ protected:
         // 3. Show the ImGui test window. Most of the sample code is in ImGui::ShowTestWindow()
         if (show_test_window)
         {
-            ImGui::SetNextWindowPos(ImVec2(650, 20), ImGuiSetCond_FirstUseEver);
+            ImGui::SetNextWindowPos(ImVec2(650, 20), ImGuiCond_FirstUseEver);
             ImGui::ShowTestWindow();
         }
 

--- a/qtimgui.pri
+++ b/qtimgui.pri
@@ -3,6 +3,7 @@ SOURCES += \
     $$PWD/imgui/imgui_draw.cpp \
     $$PWD/imgui/imgui.cpp \
     $$PWD/imgui/imgui_demo.cpp \
+    $$PWD/imgui/imgui_widgets.cpp \
     $$PWD/ImGuiRenderer.cpp \
     $$PWD/QtImGui.cpp
 


### PR DESCRIPTION
This is critical for type-in interaction like multi-line-text and ctrl+left click on float sliders.  My laptop's home-row "enter" key spawns a QT::Key_Return event.  The code only traps the num-pad event.  I added a new element to the keymap QHash, so both are trapped now.  