### PR TITLE
Cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required (VERSION 3.8.1)
+project(qtimgui)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+find_package(Qt5 COMPONENTS Core Quick Gui Widgets REQUIRED)
+
+# imgui library: bare imgui
+add_library(imgui
+  STATIC
+  imgui/imconfig.h
+  imgui/imgui_demo.cpp
+  imgui/imgui_draw.cpp
+  imgui/imgui_internal.h
+  imgui/imgui_widgets.cpp
+  imgui/imgui.cpp
+)
+target_include_directories(imgui PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/imgui)
+
+set(
+    qt_imgui_sources
+    ImGuiRenderer.h
+    ImGuiRenderer.cpp
+    QtImGui.h
+    QtImGui.cpp
+)
+
+# qt_imgui_quick: library with a qt renderer for Qml / QtQuick applications
+add_library(qt_imgui_quick STATIC ${qt_imgui_sources})
+target_include_directories(qt_imgui_quick PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(
+    qt_imgui_quick 
+    PUBLIC imgui Qt5::Core Qt5::Quick)
+
+# qt_imgui_widget: library with a qt renderer for classic Qt Widget applications
+add_library(qt_imgui_widgets STATIC ${qt_imgui_sources})
+target_include_directories(qt_imgui_widgets PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(
+    qt_imgui_widgets
+    PUBLIC imgui Qt5::Core Qt5::Widgets)
+target_compile_definitions(qt_imgui_widgets PUBLIC QT_WIDGETS_LIB)
+
+# Demo with Qt quick
+add_subdirectory(demo-widget)
+# Demo with classic widgets
+add_subdirectory(demo-window)

--- a/demo-widget/CMakeLists.txt
+++ b/demo-widget/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(
+  qt_imgui_demo_widget
+  demo-widget.cpp
+)
+target_link_libraries(
+  qt_imgui_demo_widget 
+  PRIVATE 
+  qt_imgui_widgets
+  )

--- a/demo-window/CMakeLists.txt
+++ b/demo-window/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(
+  qt_imgui_demo_window
+  demo-window.cpp
+)
+target_link_libraries(qt_imgui_demo_window 
+  PRIVATE 
+  qt_imgui_quick
+)


### PR DESCRIPTION
This adds cmake support. Thay are equivalent to the pro files, but can help 
people outside of QtCreator.

Target lists:
* imgui : bare imgui library (static)
* qt_imgui_quick: library to use in QtQuick mode
* qt_imgui_widgets: library to use in QtWidgets mode
* qt_imgui_demo_window ! demo app in QtQuick mode
* qt_imgui_demo_widgets: demo apps in widgets mode
