### PR TITLE
Cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,7 @@ Makefile*
 # QtCtreator CMake
 CMakeLists.txt.user*
 
+# CLion
+.idea
 
 # End of https://www.gitignore.io/api/qt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "imgui"]
 	path = imgui
 	url = https://github.com/ocornut/imgui.git
+[submodule "tools/qt-android-cmake"]
+	path = tools/qt-android-cmake
+	url = https://github.com/LaurentGomila/qt-android-cmake.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required (VERSION 3.8.1)
+project(qtimgui)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+find_package(Qt5 COMPONENTS Core Quick Gui Widgets Svg REQUIRED)
+
+# imgui library: bare imgui
+add_library(imgui
+  STATIC
+  imgui/imconfig.h
+  imgui/imgui_demo.cpp
+  imgui/imgui_draw.cpp
+  imgui/imgui_internal.h
+  imgui/imgui_widgets.cpp
+  imgui/imgui.cpp
+)
+target_include_directories(imgui PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/imgui)
+
+set(
+    qt_imgui_sources
+    ImGuiRenderer.h
+    ImGuiRenderer.cpp
+    QtImGui.h
+    QtImGui.cpp
+)
+
+# qt_imgui_quick: library with a qt renderer for Qml / QtQuick applications
+add_library(qt_imgui_quick STATIC ${qt_imgui_sources})
+target_include_directories(qt_imgui_quick PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(
+    qt_imgui_quick 
+    PUBLIC
+    imgui
+    Qt5::Core Qt5::Quick Qt5::Svg
+    )
+if (ANDROID)
+    target_link_libraries(qt_imgui_quick PUBLIC log dl GLESv2 z)
+endif()
+
+# qt_imgui_widget: library with a qt renderer for classic Qt Widget applications
+add_library(qt_imgui_widgets STATIC ${qt_imgui_sources})
+target_include_directories(qt_imgui_widgets PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(
+    qt_imgui_widgets
+    PUBLIC
+    imgui
+    Qt5::Core Qt5::Widgets Qt5::Svg
+    )
+if (ANDROID)
+    target_link_libraries(qt_imgui_widgets PUBLIC log dl GLESv2 z)
+endif()
+target_compile_definitions(qt_imgui_widgets PUBLIC QT_WIDGETS_LIB)
+
+# Demo with Qt quick
+add_subdirectory(demo-window)
+# Demo with classic widgets
+add_subdirectory(demo-widget)

--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ protected:
 ```
 
 See [QOpenGLWidget example](demo-widget/demo-widget.cpp) and [QOpenGLWindow example](/demo-window/demo-window.cpp) for details.
+
+## Specific notes for Android, when using cmake
+
+Two projects are provided: `qtimgui.pro` and `CMakaLists.txt`.
+
+When using cmake under Android, this project will uses [qt-android-cmake](https://github.com/LaurentGomila/qt-android-cmake), which is a CMake utility for building and deploying Qt based applications on Android without QtCreator.
+
+*In order to successfuly deploy the app to a device, the cmake variable ANDROID_NATIVE_API_LEVEL should be >= 26.
+ You will need to set it via the cmake command line, or inside Qt Creator (in the project view).*
+

--- a/demo-widget/CMakeLists.txt
+++ b/demo-widget/CMakeLists.txt
@@ -1,9 +1,11 @@
-add_executable(
-  qt_imgui_demo_widget
-  demo-widget.cpp
-)
-target_link_libraries(
-  qt_imgui_demo_widget 
-  PRIVATE 
-  qt_imgui_widgets
-  )
+if (ANDROID)
+    add_library(qt_imgui_demo_widget SHARED demo-widget.cpp)
+else()
+    add_executable(qt_imgui_demo_widget demo-widget.cpp)
+endif()
+target_link_libraries(qt_imgui_demo_widget PRIVATE qt_imgui_widgets)
+
+if(ANDROID)
+    include(${CMAKE_CURRENT_LIST_DIR}/../tools/qt-android-cmake/AddQtAndroidApk.cmake)
+    add_qt_android_apk(qt_imgui_demo_widget_apk qt_imgui_demo_widget)
+endif()

--- a/demo-widget/CMakeLists.txt
+++ b/demo-widget/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(
+  qt_imgui_demo_widget
+  demo-widget.cpp
+)
+target_link_libraries(
+  qt_imgui_demo_widget 
+  PRIVATE 
+  qt_imgui_widgets
+  )

--- a/demo-window/CMakeLists.txt
+++ b/demo-window/CMakeLists.txt
@@ -1,8 +1,11 @@
-add_executable(
-  qt_imgui_demo_window
-  demo-window.cpp
-)
-target_link_libraries(qt_imgui_demo_window 
-  PRIVATE 
-  qt_imgui_quick
-)
+if (ANDROID)
+  add_library(qt_imgui_demo_window SHARED demo-window.cpp)
+else()
+  add_executable(qt_imgui_demo_window demo-window.cpp)
+endif()
+target_link_libraries(qt_imgui_demo_window  PRIVATE qt_imgui_quick)
+
+if(ANDROID)
+    include(${CMAKE_CURRENT_LIST_DIR}/../tools/qt-android-cmake/AddQtAndroidApk.cmake)
+    add_qt_android_apk(qt_imgui_demo_window_apk qt_imgui_demo_window)
+endif()

--- a/demo-window/CMakeLists.txt
+++ b/demo-window/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(
+  qt_imgui_demo_window
+  demo-window.cpp
+)
+target_link_libraries(qt_imgui_demo_window 
+  PRIVATE 
+  qt_imgui_quick
+)


### PR DESCRIPTION
This adds cmake support. Thay are equivalent to the pro files, but can help 
people outside of QtCreator.

This PR is built on top of the fix_android PR.

Target lists:
* imgui : bare imgui library (static)
* qt_imgui_quick: library to use in QtQuick mode
* qt_imgui_widgets: library to use in QtWidgets mode
* qt_imgui_demo_window ! demo app in QtQuick mode
* qt_imgui_demo_widgets: demo apps in widgets mode

It adds a folder "android-package" which the required gradle files in order to 
deploy to an android device via cmake.


