### PR TITLE
Updated qtimgui.pri - fixed ImGui sources pathes

### DIFF
--- a/qtimgui.pri
+++ b/qtimgui.pri
@@ -1,14 +1,21 @@
 
+# Add Dear ImGui sources (QtImGui depends on it)
 SOURCES += \
-    $$PWD/src/imgui/imgui_draw.cpp \
-    $$PWD/src/imgui/imgui.cpp \
-    $$PWD/src/imgui/imgui_demo.cpp \
-    $$PWD/src/imgui/imgui_widgets.cpp \
-    $$PWD/src/ImGuiRenderer.cpp \
-    $$PWD/src/QtImGui.cpp
+    $$PWD/modules/imgui/imgui_draw.cpp \
+    $$PWD/modules/imgui/imgui.cpp \
+    $$PWD/modules/imgui/imgui_demo.cpp \
+    $$PWD/modules/imgui/imgui_widgets.cpp \
+    $$PWD/modules/imgui/imgui_tables.cpp
 
-INCLUDEPATH += $$PWD/modules/imgui $$PWD/modules/implot $$PWD/src
+INCLUDEPATH += \
+    $$PWD/modules/imgui \
+    $$PWD/modules/implot \
+    $$PWD/src
 
 HEADERS += \
     $$PWD/src/ImGuiRenderer.h \
     $$PWD/src/QtImGui.h
+
+SOURCES += \
+    $$PWD/src/ImGuiRenderer.cpp \
+    $$PWD/src/QtImGui.cpp


### PR DESCRIPTION
`Dear ImGui` sources placed in `modules` directory, not `src`. Also added missing `imgui_tables.cpp`.