### PR TITLE
Added missing feature - OS mouse cursor shape changing

### DIFF
--- a/src/ImGuiRenderer.h
+++ b/src/ImGuiRenderer.h
@@ -21,6 +21,8 @@ public:
     virtual bool isActive() const = 0;
     virtual QPoint mapFromGlobal(const QPoint &p) const = 0;
     virtual QObject* object() = 0;
+    
+    virtual void setCursorShape(Qt::CursorShape shape) = 0;
 };
 
 class ImGuiRenderer : public QObject, QOpenGLExtraFunctions {
@@ -41,6 +43,8 @@ private:
     void onMousePressedChange(QMouseEvent *event);
     void onWheel(QWheelEvent *event);
     void onKeyPressRelease(QKeyEvent *event);
+    
+    void updateCursorShape(const ImGuiIO &io);
 
     void renderDrawList(ImDrawData *draw_data);
     bool createFontsTexture();

--- a/src/QtImGui.cpp
+++ b/src/QtImGui.cpp
@@ -55,6 +55,16 @@ public:
     QObject* object() override {
         return w;
     }
+    
+    void setCursorShape(Qt::CursorShape shape) override
+    {
+        #ifndef QT_NO_CURSOR
+            w->setCursor(shape);
+        #else
+            Q_UNUSED(shape);
+        #endif
+    }
+    
 private:
     QWidget *w;
 };
@@ -100,6 +110,15 @@ public:
     }
     QObject* object() override {
         return w;
+    }
+    
+    void setCursorShape(Qt::CursorShape shape) override
+    {
+        #ifndef QT_NO_CURSOR
+            w->setCursor(shape);
+        #else
+            Q_UNUSED(shape);
+        #endif
     }
 
 private:


### PR DESCRIPTION
That allow us to resize windows by dragging their borders :)

If `io.BackendFlags : hasMouseCursors` not enabled in backend, we cannot enable `io.ConfigWindowResizeFromEdges`. This PR add this functionality.

In the next video, see how native cursor changed, when mouse hover window edges, input fields, table columns, etc.

https://user-images.githubusercontent.com/20372668/113297901-e587cf80-9303-11eb-949d-b98e94c3eab9.mp4

