### PR TITLE
Wheel : Fixed integer division, which produces zero in case of small angleDelta

### DIFF
--- a/src/ImGuiRenderer.cpp
+++ b/src/ImGuiRenderer.cpp
@@ -405,7 +405,7 @@ void ImGuiRenderer::onWheel(QWheelEvent *event)
         g_MouseWheelH += event->pixelDelta().x() / (ImGui::GetTextLineHeight());
     } else {
         // Magic number of 120 comes from Qt doc on QWheelEvent::pixelDelta()
-        g_MouseWheelH += event->angleDelta().x() / 120;
+        g_MouseWheelH += event->angleDelta().x() / 120.0f;
     }
 
     // Handle vertical component
@@ -415,7 +415,7 @@ void ImGuiRenderer::onWheel(QWheelEvent *event)
         g_MouseWheel += event->pixelDelta().y() / (5.0 * ImGui::GetTextLineHeight());
     } else {
         // Magic number of 120 comes from Qt doc on QWheelEvent::pixelDelta()
-        g_MouseWheel += event->angleDelta().y() / 120;
+        g_MouseWheel += event->angleDelta().y() / 120.0f;
     }
 }
 


### PR DESCRIPTION
During experiments with `qtimgui` in **browser** (by using Qt for webassembly + small shaders tweaking), I found, that mouse wheel not works.

Looking into raw `QWheelEvent` data, I see the next:
- `event->pixelDelta() {x: 0, y: 0} | event->angleDelta() {x = 0, y: 53}` (rotation up)
- `event->pixelDelta() {x: 0, y: 0} | event->angleDelta() {x = 0, y: -53}` (rotation down)

So, due to integers division, if `event->angleDelta()` is less then `120`, value assigned to `(float) g_mouseWheelH` or `(float) g_mouseWheel` is always `0` - that's why mouse scrolling not works (in my case).

This merge request fixes it :)