### PR TITLE
Enforce no zero DeltaTime

### DIFF
--- a/src/ImGuiRenderer.cpp
+++ b/src/ImGuiRenderer.cpp
@@ -330,6 +330,7 @@ void ImGuiRenderer::newFrame()
     // Setup time step
     double current_time =  QDateTime::currentMSecsSinceEpoch() / double(1000);
     io.DeltaTime = g_Time > 0.0 ? (float)(current_time - g_Time) : (float)(1.0f/60.0f);
+    if (io.DeltaTime <= 0.0f) io.DeltaTime = 0.00001f;
     g_Time = current_time;
     
     


### PR DESCRIPTION
When rapidly resizing a Qt window, DeltaTime can be zero (crash). This is a simple patch, according to https://github.com/ocornut/imgui/issues/4680