### PR TITLE
FIX: imgui hovering when other widget is focused

### DIFF
--- a/src/ImGuiRenderer.cpp
+++ b/src/ImGuiRenderer.cpp
@@ -359,7 +359,11 @@ void ImGuiRenderer::newFrame()
     }
     else
     {
-        io.MousePos = ImVec2(-1,-1);
+        //https://github.com/ocornut/imgui/blob/031e152d292b386b7b6149e455924cfc6bab8c7c/imgui.h#L2048
+        // Mouse position, in pixels. Set to ImVec2(-FLT_MAX, -FLT_MAX) if mouse is unavailable (on another screen, etc.)
+        //https://github.com/ocornut/imgui/blob/fd943182bd9fe1d801e721a20a41dcde84be39d0/imgui.cpp#L679
+        // - 2017/08/25 (1.52) - io.MousePos needs to be set to ImVec2(-FLT_MAX,-FLT_MAX) when mouse is unavailable/missing. Previously ImVec2(-1,-1) was enough but we now accept negative mouse coordinates. In your backend if you need to support unavailable mouse, make sure to replace "io.MousePos = ImVec2(-1,-1)" with "io.MousePos = ImVec2(-FLT_MAX,-FLT_MAX)".
+        io.MousePos = ImVec2(-FLT_MAX,-FLT_MAX);
     }
 
     for (int i = 0; i < 3; i++)

--- a/src/QtImGui.cpp
+++ b/src/QtImGui.cpp
@@ -47,7 +47,14 @@ public:
         return w->devicePixelRatioF();
     }
     bool isActive() const override {
-        return w->isActiveWindow() && w->hasFocus();
+        // the window containing the widget top-level window that currently has focus
+        //return w->isActiveWindow();
+      
+        // the widget is the one with focus among the window wigets
+        //return w->isActiveWindow() && w->hasFocus();
+
+        // the widget area is under the mouse, but it seems like other widgets being open/focused cancel it e.g. an open combo box
+        return w->isActiveWindow() && w->underMouse();
     }
     QPoint mapFromGlobal(const QPoint &p) const override {
         return w->mapFromGlobal(p);

--- a/src/QtImGui.cpp
+++ b/src/QtImGui.cpp
@@ -47,7 +47,7 @@ public:
         return w->devicePixelRatioF();
     }
     bool isActive() const override {
-        return w->isActiveWindow();
+        return w->isActiveWindow() && w->hasFocus();
     }
     QPoint mapFromGlobal(const QPoint &p) const override {
         return w->mapFromGlobal(p);


### PR DESCRIPTION
Fixes https://github.com/seanchas116/qtimgui/issues/52

* I took the approach of modifying the `isActive()` virtual function for only the widget and let the polymorphism do nothing new for windows.
* I also modified the value set to MousePos whenever the wrapper is inactive as mentioned in https://github.com/ocornut/imgui/blob/fd943182bd9fe1d801e721a20a41dcde84be39d0/imgui.cpp#L679

Feel free to do edits to the PR.