### PR TITLE
Add ImPlot source files to qtimgui.pri

### DIFF
--- a/qtimgui.pri
+++ b/qtimgui.pri
@@ -5,7 +5,10 @@ SOURCES += \
     $$PWD/modules/imgui/imgui.cpp \
     $$PWD/modules/imgui/imgui_demo.cpp \
     $$PWD/modules/imgui/imgui_widgets.cpp \
-    $$PWD/modules/imgui/imgui_tables.cpp
+    $$PWD/modules/imgui/imgui_tables.cpp \
+    $$PWD/modules/implot/implot.cpp \
+    $$PWD/modules/implot/implot_demo.cpp \
+    $$PWD/modules/implot/implot_items.cpp
 
 INCLUDEPATH += \
     $$PWD/modules/imgui \


### PR DESCRIPTION
For using the implot lib also via the
qtimgui.pri file the according source files
need to be present.
Adding the missing files.